### PR TITLE
refactor: use lazy-require to avoid cycle loading error

### DIFF
--- a/src/ch3/proc-lang/ds-rep/environment.rkt
+++ b/src/ch3/proc-lang/ds-rep/environment.rkt
@@ -1,7 +1,8 @@
 #lang eopl
 
-(require "value.rkt")
+(require racket/lazy-require)
 (require "basic.rkt")
+(lazy-require ["value.rkt" (num-val)])
 (provide (all-defined-out))
 
 (define (empty-env) '())

--- a/src/ch3/proc-lang/ds-rep/expression.rkt
+++ b/src/ch3/proc-lang/ds-rep/expression.rkt
@@ -1,7 +1,10 @@
 #lang eopl
 
-(provide (all-defined-out))
+(require racket/lazy-require)
 (require "basic.rkt")
+(lazy-require ["value.rkt" (num-val)])
+
+(provide (all-defined-out))
 
 (define-datatype expression expression?
   (const-exp

--- a/src/ch3/proc-lang/ds-rep/interpreter.rkt
+++ b/src/ch3/proc-lang/ds-rep/interpreter.rkt
@@ -4,7 +4,6 @@
 (require "expression.rkt")
 (require "environment.rkt")
 (require "value.rkt")
-(require "procedure.rkt")
 (provide (all-defined-out))
 
 (define (run str)

--- a/src/ch3/proc-lang/ds-rep/value.rkt
+++ b/src/ch3/proc-lang/ds-rep/value.rkt
@@ -1,6 +1,10 @@
 #lang eopl
 
+(require racket/lazy-require)
 (require "basic.rkt")
+(require "expression.rkt")
+(lazy-require ["environment.rkt" (environment?)])
+
 (provide (all-defined-out))
 
 (define-datatype expval expval?
@@ -15,7 +19,22 @@
    (first expval?)
    (second expval?)
    )
+  (proc-val (proc! proc?))
   )
+
+(define-datatype proc proc?
+  (procedure
+   (vars (list-of identifier?))
+   (body expression?)
+   (saved-env environment?)
+   )
+  (trace-procedure
+   (vars (list-of identifier?))
+   (body expression?)
+   (saved-env environment?)
+   )
+  )
+
 
 (define (expval->num val)
   (cases expval val


### PR DESCRIPTION
File expression.rkt/environment.rkt/value.rkt depend on each other forming a loading cycle, which causes a error raised when using require.