### PR TITLE
feat: more type checking for cast/instanceof

### DIFF
--- a/base/test.rkt
+++ b/base/test.rkt
@@ -3832,3 +3832,100 @@ in list(
             " '(#t #f #f #t #f #f) "equal method by double dispatch")
    )
   )
+
+(define test-cases-instanceof
+  (list
+   (list "
+class parent extends object
+  method int initialize() 1
+
+class child extends parent
+  method int initialize() 2
+  method int value() 2
+
+let c = new child()
+in instanceof c child
+             " #t "child is instance of its class")
+
+   (list "
+class parent extends object
+  method int initialize() 1
+
+class child extends parent
+  method int initialize() 2
+  method int value() 2
+
+let c = new child()
+in instanceof c parent
+             " #t "child is instance of its ancestor class")
+
+   (list "
+class parent extends object
+  method int initialize() 1
+
+class child extends parent
+  method int initialize() 2
+  method int value() 2
+
+let p = new parent()
+in instanceof p child
+             " #f "p is not instance of its sub class")
+   )
+  )
+
+(define test-cases-cast
+  (list
+   (list "
+class parent extends object
+  method int initialize() 1
+
+class child extends parent
+  method int initialize() 2
+  method int value() 2
+
+let c = new child()
+in let test-cast = proc (p: parent) send cast p child value()
+in list((test-cast c))
+             " '(2) "cast parent to child")
+
+   (list "
+class parent extends object
+  method int initialize() 1
+
+class child extends parent
+  method int initialize() 2
+  method int value() 2
+
+let c = new child()
+in cast c parent
+            " 'error "no need to cast to parent type, error on this")
+
+   (list "
+class Animal extends object
+  method int initialize() 1
+
+class Fruit extends object
+  method int initialize() 2
+
+let f = new Fruit()
+in cast f Animal
+            " 'error "error when cast to class type with no inheritance relationship")
+
+   (list "
+class Animal extends object
+  method int initialize() 1
+
+class Fruit extends object
+  method int initialize() 2
+
+cast 1 Animal
+            " 'error "can only cast object")
+   )
+  )
+
+(define test-cases-9.33-9.34
+  (append
+   test-cases-instanceof
+   test-cases-cast
+   )
+  )

--- a/ch9/9.5/exer-9.33-9.34/test.rkt
+++ b/ch9/9.5/exer-9.33-9.34/test.rkt
@@ -1,0 +1,14 @@
+#lang eopl
+
+(require "../typed-oo/interpreter.rkt")
+(require "../typed-oo/value.rkt")
+(require "../../../base/test.rkt")
+
+(test-lang run sloppy->expval
+           (append
+            test-cases-checked-lang
+            test-cases-typed-list
+            test-cases-typed-oo
+            test-cases-9.33-9.34
+            )
+           )

--- a/ch9/9.5/typed-oo/checker/static-class.rkt
+++ b/ch9/9.5/typed-oo/checker/static-class.rkt
@@ -296,6 +296,32 @@
    )
   )
 
+; 1. true when name1 is subclass of name2 or name2 is subclass of name1
+; 2. true when name1 is a class which implements interface name2
+; 3. true when name2 is a class which implements interface name1
+; 4. error when name1/name2 both is interface, current language doesn't support inheritance between interfaces,
+; so we don't handle this case.
+(define (statically-is-instanceofable? name1 name2)
+  (cases static-class (lookup-static-class name1)
+    (a-static-class (super-name interface-names field-names field-types method-tenv)
+                    (or
+                     (statically-is-subclass? name1 name2)
+                     (statically-is-subclass? name2 name1)
+                     )
+                    )
+    (an-interface (method-tenv)
+                  (cases static-class (lookup-static-class name2)
+                    (a-static-class (super-name interface-names field-names field-types method-tenv)
+                                    (statically-is-subclass? name2 name1)
+                                    )
+                    (an-interface (method-tenv)
+                                  (eopl:error 'statically-is-compatible? "type ~s is not compatible with type ~s" name1 name2)
+                                  )
+                    )
+                  )
+    )
+  )
+
 (define (lookup-static-class name)
   (let ([maybe-pair (assq name the-static-class-env)])
     (if maybe-pair

--- a/ch9/9.5/typed-oo/class.rkt
+++ b/ch9/9.5/typed-oo/class.rkt
@@ -101,8 +101,7 @@
                           (list method-name (a-method vars body super-name field-names))
                           )
            (an-abstract-method-decl (result-type method-name vars var-types)
-                                    ;  TODO:
-                                    1
+                                    (eopl:error 'method-decls->method-env "Invalid abstract method decl on class ~s" m-decl)
                                     )
            )
          ) m-decls)
@@ -152,7 +151,7 @@
       #t
       (let ([super-name (class->super-name (lookup-class class1))])
         (if super-name
-            (is-subclass? class1 class2)
+            (is-subclass? super-name class2)
             #f
             )
         )


### PR DESCRIPTION
1. cast/instanceof requires object, which is type of some class
2. allow cast to sub class type only
3. allow instanceof when two types has inheritance class relationship

exer 9.33/exer 9.34